### PR TITLE
Update postgresql-managed-service.md

### DIFF
--- a/docs/managed-services/postgresql-managed-service.md
+++ b/docs/managed-services/postgresql-managed-service.md
@@ -79,7 +79,7 @@ kind: ManagedService
 name: db
 spec:
   service_name: postgresql
-  version: 10.4
+  version: '10.4'
   parameters:
     - name: adminer_enabled
       value: true
@@ -112,7 +112,7 @@ kind: ManagedService
 name: db
 spec:
   service_name: postgresql
-  version: 10.4
+  version: '10.4'
   parameters:
     - name: adminer_enabled
       value: true


### PR DESCRIPTION
Update postgresql managed service sample deployment manifest
Wrapped postgresql managed service version number in quotations due to the following error during service deployment with the cli
> PostgreSQL: ["PostgreSQL supported versions are ['10.4', '9.5', '9.5.25', '9.6', '9', '11', '11.11', '12.6', '12', '13.2', '13']"]

This error happens on executing the following command with quote-less version number
```bash
fandogh service apply -f postgresql_deployment.yml
```